### PR TITLE
Optimize non-mutating rng dispatch on v1.12.0

### DIFF
--- a/src/random.jl
+++ b/src/random.jl
@@ -8,19 +8,32 @@ const DenseSignArrays = Union{
     Base.FastContiguousSubArray{UInt8,N,<:DenseArray{Sign}}
 } where {N}
 
-function rand!(rng::AbstractRNG, A::DenseSignArrays)
-    # UnsafeView creates a writeable view that treats A as a Bool array
-    # Allows writing the bits of rand!(Array{Bool}) into A without allocating new memory
-    GC.@preserve A rand!(rng, UnsafeView{Bool}(pointer(A), length(A)), SamplerType{Bool}())
-    return A
-end
+@static if VERSION >= v"1.12"
+    # This only works properly because of JuliaLang/julia#57101
+    # More complicated than the alternative version, but seems to be more canonical
+    function rand!(rng::AbstractRNG, A::DenseSignArrays)
+        # UnsafeView creates a writeable view that treats A as a Bool array
+        # Allows writing the bits of rand!(Array{Bool}) into A without allocating new memory
+        GC.@preserve A rand!(rng, UnsafeView{Bool}(pointer(A), length(A)), SamplerType{Bool}())
+        return A
+    end
 
-# The below method fixes dispatch from the non-mutating vector call to the mutating rand call
-rand!(rng::AbstractRNG, A::DenseSignArrays, sp::Sampler) = rand!(rng, A)
+    # The below method fixes dispatch from the non-mutating vector call to the mutating rand call
+    rand!(rng::AbstractRNG, A::DenseSignArrays, sp::Sampler) = rand!(rng, A)
 
-function rand(rng::AbstractRNG, ::SamplerType{Sign}, dim1::Integer, extra_dims::Integer...)
-    # Strange function signature to avoid method ambiguities
-    A = Array{Sign}(undef, Dims(dim1, extra_dims...))
-    rand!(rng, A)
-    return A
+    function rand(rng::AbstractRNG, ::SamplerType{Sign}, dim1::Integer, extra_dims::Integer...)
+        # Strange function signature to avoid method ambiguities
+        A = Array{Sign}(undef, Dims(dim1, extra_dims...))
+        rand!(rng, A)
+        return A
+    end
+else
+    function rand!(rng::AbstractRNG, A::DenseSignArrays)
+        # This method is sus, but seems to work with no noticeable overhead
+        rand!(rng, reinterpret(Bool, A))
+        return A
+    end
+    
+    # No noticeable overhead
+    rand(rng::AbstractRNG, ::SamplerType{Sign}, dim1::Integer, extra_dims::Integer...) = reinterpret(Sign, rand(rng, SamplerType(Bool), dim1, extra_dims...))
 end

--- a/src/random.jl
+++ b/src/random.jl
@@ -1,4 +1,4 @@
-import Random: rand, rand!, AbstractRNG, SamplerType, TaskLocalRNG, Xoshiro, UnsafeView
+import Random: rand, rand!, AbstractRNG, SamplerType, TaskLocalRNG, Xoshiro, UnsafeView, Sampler
 
 rand(rng::AbstractRNG, ::SamplerType{Sign})::Sign = reinterpret(Sign, rand(rng, Bool))
 
@@ -14,6 +14,9 @@ function rand!(rng::AbstractRNG, A::DenseSignArrays)
     GC.@preserve A rand!(rng, UnsafeView{Bool}(pointer(A), length(A)), SamplerType{Bool}())
     return A
 end
+
+# The below method fixes dispatch from the non-mutating vector call to the mutating rand call
+rand!(rng::AbstractRNG, A::DenseSignArrays, sp::Sampler) = rand!(rng, A)
 
 function rand(rng::AbstractRNG, ::SamplerType{Sign}, dim1::Integer, extra_dims::Integer...)
     # Strange function signature to avoid method ambiguities

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -393,7 +393,7 @@ const SIGNED_RATIONALS = map(T -> Rational{T}, SIGNED_TYPES)
         Y = rand(Random.Xoshiro(1234), Sign, 1000)
         # This test probably breaks due to a change in dispatch
         # (scalar vs. vector methods)
-        @test X == Y broken = (VERSION >= v"1.12")
+        @test X == Y
         Random.rand!(X)
         @test X != Y
         Random.rand!(Y)


### PR DESCRIPTION
Debugged using TraceFuns.jl on v1.11.8, this should resolve the broken test on v1.12.

The funny thing about the test is that it was sort of a red herring. The previous situation was:

- I wrote code to dispatch to vectorized algorithms for both `rand!(Sign, X)`` and `rand(Sign, n)` referencing v1.12.0 source code, but implemented on a pre-v1.12.0 version

- On pre-v1.12.0 versions, neither `rand` nor `rand!` actually dispatched to the vectorized algorithms (oops!)

- On v1.12.0, only `rand!` was dispatching to the vectorized algorithm.

- The non-vectorized algorithm and the vectorized algorithm give different results, which was causing the test failure for v1.12.0

- Nothing was truly broken besides performance losses (except `rand!` on v1.12.0 and later, which was performing optimally)

----

My preferred method of debugging these dispatch paths is TraceFuns.jl, which uses Casette.jl, which doesn't work on v1.12 yet . . . oof.

This fix unifies the dispatch paths of `rand!` and vector `rand` better via the addition of a more specific method signature. It should follow the vectorized dispatch path for both methods in v1.12.0 and onward now.

Unfortunately, it still follows the scalar dispatch path on versions older than v1.12; I'm going to experiment later with sets of methods that are optimized in both versions.
